### PR TITLE
Problem with dependencies conflict

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,13 +19,14 @@ libraryDependencies ++= Seq(
   "bio4j" % "bio4j" % "0.12.0-SNAPSHOT",
   "ohnosequences" % "bioinfo-util" % "1.4.0-SNAPSHOT",
   "org.apache.commons" % "commons-math" % "2.2",
-  "junit" % "junit" % "3.8.1" % "test",
-  "net.sf.opencsv" % "opencsv" % "2.3"
+  "net.sf.opencsv" % "opencsv" % "2.3",
+  "junit" % "junit" % "4.11" % "test"
 )
 
 dependencyOverrides ++= Set(
   "com.fasterxml.jackson.core" % "jackson-core" % "2.1.2",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.1.2",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.1.2",
   "commons-beanutils" % "commons-beanutils" % "1.8.3",
   "commons-beanutils" % "commons-beanutils-core" % "1.8.3",
   "commons-codec" % "commons-codec" % "1.6",


### PR DESCRIPTION
Hey!

I'm trying to solve this denpendency conflict issue without much luck:

``` bash
[error] com.fasterxml.jackson.core#jackson-annotations;2.1.1 (needed by [com.amazonaws#aws-java-sdk;1.6.8]) co
nflicts with com.fasterxml.jackson.core#jackson-annotations;2.1.2 (needed by [com.fasterxml.jackson.core#jacks
on-databind;2.1.2])
[trace] Stack trace suppressed: run last *:update for the full output.
[error] (*:update) org.apache.ivy.plugins.conflict.StrictConflictException: com.fasterxml.jackson.core#jackson
-annotations;2.1.1 (needed by [com.amazonaws#aws-java-sdk;1.6.8]) conflicts with com.fasterxml.jackson.core#ja
ckson-annotations;2.1.2 (needed by [com.fasterxml.jackson.core#jackson-databind;2.1.2])
[error] Total time: 7 s, completed Jul 8, 2014 10:14:17 AM
>
```

I've tried to change the build.sbt to:

```
dependencyOverrides ++= Set(
  "com.fasterxml.jackson.core" % "jackson-core" % "2.1.1",
  "com.fasterxml.jackson.core" % "jackson-databind" % "2.1.1",
  "commons-beanutils" % "commons-beanutils" % "1.8.3",
  "commons-beanutils" % "commons-beanutils-core" % "1.8.3",
  "commons-codec" % "commons-codec" % "1.6",
  "net.sf.opencsv" % "opencsv" % "2.3"
)
```

but it still doesn't work..
any ideas?
@laughedelic @eparejatobes 
